### PR TITLE
Prevent text selection when clicking on the name

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,13 @@
       
       #package-name {
         cursor: pointer;
+        /* Prevent selection when fast clicking on the name */
+        -webkit-touch-callout: none;
+        -webkit-user-select: none;
+        -khtml-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
       }
 
       .mastfoot {


### PR DESCRIPTION
You can now click very fast on the package name without it highlighting the name. This was an issue on the macbook pro.
